### PR TITLE
情報が登録されていない場合の分岐表示を追加

### DIFF
--- a/app/views/gummies/index.html.erb
+++ b/app/views/gummies/index.html.erb
@@ -1,12 +1,16 @@
 <div class="gummy_index">
-  <% @gummies.each_with_index do |gummy, i| %>
-    <%= link_to gummy_path(gummy.id) do %>
-      <div class="gummy_list">
-        <p id="gummy-name-<%= i %>"><%= gummy.name %></p>
-        <div class="gummy_image_div" id="gummy-image-<%= i %>">
-          <%= image_tag "#{gummy.image}" %>
+  <% if @gummies == [] %>
+    <p>グミの情報が登録されていません</p>
+  <% else %>
+    <% @gummies.each_with_index do |gummy, i| %>
+      <%= link_to gummy_path(gummy.id) do %>
+        <div class="gummy_list">
+          <p id="gummy-name-<%= i %>"><%= gummy.name %></p>
+          <div class="gummy_image_div" id="gummy-image-<%= i %>">
+            <%= image_tag "#{gummy.image}" %>
+          </div>
         </div>
-      </div>
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/users/map.html.erb
+++ b/app/views/users/map.html.erb
@@ -1,5 +1,5 @@
 <div class="user_map">
-  <%if @spot == [] %>
+  <% if @spots == [] %>
     <p>投稿した目撃情報がありません</p>
   <% else %>
     <% @spots.each_with_index do |spot, i| %>

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -127,51 +127,87 @@ RSpec.feature "user機能のfeatureテスト", type: :feature do
   end
 
   feature "users#review" do
-    background do
-      visit login_path
-      fill_in 'session-name-form', with: "#{user.email}"
-      fill_in 'session-password-form', with: "#{user.password}"
-      click_on "Log in"
-      visit "/users/#{user.id}/review"
+    let(:user_not_posted_review) { create(:user) }
+
+    context "レビューを投稿済みの場合" do
+      background do
+        visit login_path
+        fill_in 'session-name-form', with: "#{user.email}"
+        fill_in 'session-password-form', with: "#{user.password}"
+        click_on "Log in"
+        visit "/users/#{user.id}/review"
+      end
+
+      scenario "投稿したレビューが表示されること" do
+        expect(page).to have_selector '#user-review-comment-0', text: review.comment
+        expect(page).to have_selector '#user-review-comment-1', text: review2.comment
+      end
+
+      scenario "商品名クリック時に商品詳細ページにアクセス" do
+        click_on "#{gummy.name}"
+        expect(current_path).to eq gummy_path(gummy.id)
+      end
+
+      scenario "編集ボタンクリック時に正しいリンク先へアクセス" do
+        click_on 'user-review-edit-button-0' # idで指定
+        expect(current_path).to eq edit_review_path(review.id)
+      end
     end
 
-    scenario "投稿したレビューが表示されること" do
-      expect(page).to have_selector '#user-review-comment-0', text: review.comment
-      expect(page).to have_selector '#user-review-comment-1', text: review2.comment
-    end
+    context "レビューを投稿していない場合" do
+      background do
+        visit login_path
+        fill_in 'session-name-form', with: "#{user_not_posted_review.email}"
+        fill_in 'session-password-form', with: "#{user_not_posted_review.password}"
+        click_on "Log in"
+        visit "/users/#{user_not_posted_review.id}/review"
+      end
 
-    scenario "商品名クリック時に商品詳細ページにアクセス" do
-      click_on "#{gummy.name}"
-      expect(current_path).to eq gummy_path(gummy.id)
-    end
-
-    scenario "編集ボタンクリック時に正しいリンク先へアクセス" do
-      click_on 'user-review-edit-button-0' # idで指定
-      expect(current_path).to eq edit_review_path(review.id)
+      scenario "「投稿したレビューがありません」と表示されること" do
+        expect(page).to have_content "投稿したレビューがありません"
+      end
     end
   end
 
   feature "users#map" do
-    background do
-      visit login_path
-      fill_in 'session-name-form', with: "#{user.email}"
-      fill_in 'session-password-form', with: "#{user.password}"
-      click_on "Log in"
-      visit "/users/#{user.id}/map"
+    let(:user_not_posted_spot) { create(:user) }
+
+    context "目撃情報を投稿済みの場合" do
+      background do
+        visit login_path
+        fill_in 'session-name-form', with: "#{user.email}"
+        fill_in 'session-password-form', with: "#{user.password}"
+        click_on "Log in"
+        visit "/users/#{user.id}/map"
+      end
+
+      scenario "投稿したレビューが表示されること" do
+        expect(page).to have_selector '#user-map-address-0', text: spot.address
+      end
+
+      scenario "商品名クリック時に商品詳細ページにアクセス" do
+        click_on "#{gummy.name}"
+        expect(current_path).to eq "/gummies/#{gummy.id}/map"
+      end
+
+      scenario "編集ボタンクリック時に正しいリンク先へアクセス" do
+        click_on 'user-map-edit-button-0' # idで指定
+        expect(current_path).to eq edit_spot_path(spot.id)
+      end
     end
 
-    scenario "投稿したレビューが表示されること" do
-      expect(page).to have_selector '#user-map-address-0', text: spot.address
-    end
+    context "目撃情報を投稿していない場合" do
+      background do
+        visit login_path
+        fill_in 'session-name-form', with: "#{user_not_posted_spot.email}"
+        fill_in 'session-password-form', with: "#{user_not_posted_spot.password}"
+        click_on "Log in"
+        visit "/users/#{user_not_posted_spot.id}/map"
+      end
 
-    scenario "商品名クリック時に商品詳細ページにアクセス" do
-      click_on "#{gummy.name}"
-      expect(current_path).to eq "/gummies/#{gummy.id}/map"
-    end
-
-    scenario "編集ボタンクリック時に正しいリンク先へアクセス" do
-      click_on 'user-map-edit-button-0' # idで指定
-      expect(current_path).to eq edit_spot_path(spot.id)
+      scenario "「投稿した目撃情報がありません」と表示されること" do
+        expect(page).to have_content "投稿した目撃情報がありません"
+      end
     end
   end
 end


### PR DESCRIPTION
・users#mapのビューで、map情報を登録していない場合の分岐にミスが有ったため修正。
・gummies#indexのビューで、グミの情報が登録されていない場合の表示の分岐を追加。
・上記２点のテストを追加。