### PR TITLE
ゲストユーザー機能の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,4 +39,11 @@ class ApplicationController < ActionController::Base
       redirect_to root_path
     end
   end
+
+  def guest_user?
+    if guest_user
+      flash[:notice] = "ゲストユーザーは使用できません"
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
   before_action :correct_account?, only: [:edit, :show, :update, :destroy, :review, :map]
   before_action :not_logged_in_user, only: [:new]
   before_action :admin_user?, only: [:index]
+  before_action :guest_user?, only: [:edit, :update, :destroy]
 
   def index
     @users = User.all

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -35,4 +35,10 @@ module SessionsHelper
   def admin_user
     User.find_by(id: session[:user_id]).admin
   end
+
+  def guest_user
+    unless User.find_by(email: "guest@example.com").nil?
+      session[:user_id] == User.find_by(email: "guest@example.com").id
+    end
+  end
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,5 +1,6 @@
 <div class="session_login">
   <h3>ログイン</h3>
+  <h5>ゲストユーザを使用できます。メールアドレス：guest@example.com,パスワード：password</h5>
   <div class="login_error_message">
     <%= @login_error_message %>
   </div>

--- a/db/migrate/20210802112244_insert_initial_users.rb
+++ b/db/migrate/20210802112244_insert_initial_users.rb
@@ -1,0 +1,5 @@
+class InsertInitialUsers < ActiveRecord::Migration[6.1]
+  def change
+    User.create(name: "guest", email: "guest@example.com", password: "password", password_confirmation: "password",)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_30_190100) do
+ActiveRecord::Schema.define(version: 2021_08_02_112244) do
 
   create_table "flavors", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe SessionsHelper, type: :helper do
   let(:user) { create(:user) }
   let(:user2) { create(:user) }
+  let(:user_admin) { create(:user, admin: true) }
+  let(:user_guest) { create(:user, email: "guest@example.com") }
 
   before do
     log_in(user)
@@ -60,5 +62,17 @@ RSpec.describe SessionsHelper, type: :helper do
     log_out
     expect(session[:user_id]).to eq nil
     expect(session[:user_name]).to eq nil
+  end
+
+  it "admin_userメソッドのテスト" do
+    log_out
+    log_in(user_admin)
+    expect(admin_user).to eq true
+  end
+
+  it "guest_userメソッドのテスト" do
+    log_out
+    log_in(user_guest)
+    expect(guest_user).to eq true
   end
 end


### PR DESCRIPTION
●ゲストユーザー機能
　・ゲストユーザーを初期データとして登録
　・ゲストユーザーのログイン情報をログインページに表示
　・ゲストユーザーはアカウントの編集と削除ができないように設定